### PR TITLE
feat: add keybind to switch wallpaper

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -117,6 +117,8 @@ static const Key keys[] = {
 	{ MODKEY, XK_Return, spawn, {.v = termcmd } },
     { MODKEY, XK_space, spawn, {.v = dmenucmd } },
 
+    { MODKEY|ShiftMask, XK_w, spawn, SHCMD("$HOME/scripts/set-wallpaper") },
+
     // multi-monitor control
 	{ MODKEY, XK_bracketleft, focusmon, {.i = +1 } },
 	{ MODKEY|ShiftMask, XK_bracketleft, tagmon, {.i = +1 } },


### PR DESCRIPTION
This PR introduces a new keybind (`super + shift + w`) that lets users quickly switch between wallpapers using the [set-wallpaper script](https://github.com/eoSalinas/scripts/blob/main/set-wallpaper).

The script automatically generates a color scheme based on the wallpaper's colors using `pywall16` and updates the `Xresources` configuration accordingly.