### PR TITLE
refactor: support `XDG` base directory for script paths

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -113,7 +113,7 @@ static const Key keys[] = {
 	{ MODKEY, XK_Return, spawn, {.v = termcmd } },
     { MODKEY, XK_space, spawn, {.v = dmenucmd } },
 
-    { MODKEY|ShiftMask, XK_w, spawn, SHCMD("$HOME/scripts/set-wallpaper") },
+    { MODKEY|ShiftMask, XK_w, spawn, SHCMD("$XDG_CONFIG_HOME/scripts/set-wallpaper") },
 
     // multi-monitor control
 	{ MODKEY, XK_bracketleft, focusmon, {.i = +1 } },
@@ -122,13 +122,13 @@ static const Key keys[] = {
 	{ MODKEY|ShiftMask, XK_bracketright, tagmon, {.i = -1 } },
 
     // volume control
-	{ 0, XK_F1, spawn, SHCMD("$HOME/scripts/volume mute") },
-    { 0, XK_F2, spawn, SHCMD("$HOME/scripts/volume down") },
-	{ 0, XK_F3, spawn, SHCMD("$HOME/scripts/volume up") },
+	{ 0, XK_F1, spawn, SHCMD("$XDG_CONFIG_HOME/scripts/volume mute") },
+    { 0, XK_F2, spawn, SHCMD("$XDG_CONFIG_HOME/scripts/volume down") },
+	{ 0, XK_F3, spawn, SHCMD("$XDG_CONFIG_HOME/scripts/volume up") },
 
     // brightness control
-	{ 0, XK_F11, spawn, SHCMD("$HOME/scripts/screenlight down") },
-    { 0, XK_F12, spawn, SHCMD("$HOME/scripts/screenlight up") },
+	{ 0, XK_F11, spawn, SHCMD("$XDG_CONFIG_HOME/scripts/screenlight down") },
+    { 0, XK_F12, spawn, SHCMD("$XDG_CONFIG_HOME/scripts/screenlight up") },
 };
 
 /* button definitions */


### PR DESCRIPTION
This PR refactors the keybindings in **dwm** to use the [XDG Base Directory](https://wiki.archlinux.org/title/XDG_Base_Directory) specification for locating scripts, instead of using hardcoded paths like `$HOME/scripts/`.

### Changes:
- Updated keybindings that run scripts (e.g., wallpaper, volume, brightness controls) to use `$XDG_CONFIG_HOME/scripts/` instead of `$HOME/scripts/`.
- This aligns the keybinding script paths with the XDG Base Directory standard, improving compatibility and making the setup more flexible.

#### Additional Notes:
If you’re setting up your environment to fully use the XDG Base Directory, you might also want to ensure the XDG environment variables are configured.

For setting these up, check out the related [repository with .zprofile](https://github.com/eoSalinas/dots/blob/main/.zprofile) where these variables can be set globally.
